### PR TITLE
Added URL encoding for searchQuery term

### DIFF
--- a/pySearch.py
+++ b/pySearch.py
@@ -8,8 +8,16 @@ argparser = argparse.ArgumentParser()
 argparser.add_argument("-s", help="Takes a query to search for and searches it.", nargs="*")
 argparser.add_argument("-e", "--engine", help="Changes the name or alias of a search engine and sets it as the search engine for the session", nargs="+")
 argparser.add_argument("-d", "--domain", help="Changes the domain extention", nargs="+")
+argparser.add_argument("-b", "--browser", help="Changes browser to perform search in", nargs="+")
 
 args = argparser.parse_args()
+
+#print available broswers
+def printAvailableBrowsers(invalid):
+        print("You have selected an invalid or unreigstered browser: " + invalid + ".\nHere is a list of available browsers")
+        for i in webbrowser._browsers:
+            print("\t"+i)
+#end of printAvailableBrowsers
 
 class Search:
     def __init__(self, searchIn = None, engineIn = "google", domainIn = "ca"):
@@ -19,7 +27,7 @@ class Search:
         self.domain = domainIn
         self.url = "";
         self.searchString = "/search?q="
-    #end of constructor
+    #end of constructor    
 
     #set search engine
     def setEngine(self, engineIn):
@@ -44,7 +52,11 @@ class Search:
     #end of link building
 
     def openBrowser(self):
-        webbrowser.open_new_tab(self.url)
+        try:
+            browser = webbrowser.get(args.browser[0])
+            browser.open_new_tab(self.url)
+        except:
+            printAvailableBrowsers(args.browser[0])
     #end of openBrowser()
 #end of Query
 

--- a/pySearch.py
+++ b/pySearch.py
@@ -1,5 +1,6 @@
 #jrkong's command line searcher
 
+from urllib.parse import quote
 import urllib
 import argparse
 import webbrowser
@@ -48,7 +49,7 @@ class Search:
         else:
             self.searchQuery = "+".join(self.searchRaw)
         #end of search exceptions
-        self.url = "http://www." + self.engine + "." + self.domain + self.searchString + self.searchQuery
+        self.url = "http://www." + self.engine + "." + self.domain + self.searchString + quote(self.searchQuery.encode('utf8'))
     #end of link building
 
     def openBrowser(self):

--- a/pySearch.py
+++ b/pySearch.py
@@ -6,19 +6,11 @@ import argparse
 import webbrowser
 
 argparser = argparse.ArgumentParser()
-argparser.add_argument("-s", help="Takes a query to search for and searches it.", nargs="*")
+argparser.add_argument("-s", action="append", help="Takes a query to search for and searches it.", nargs="*")
 argparser.add_argument("-e", "--engine", help="Changes the name or alias of a search engine and sets it as the search engine for the session", nargs="+")
 argparser.add_argument("-d", "--domain", help="Changes the domain extention", nargs="+")
-argparser.add_argument("-b", "--browser", help="Changes browser to perform search in", nargs="+")
 
 args = argparser.parse_args()
-
-#print available broswers
-def printAvailableBrowsers(invalid):
-        print("You have selected an invalid or unreigstered browser: " + invalid + ".\nHere is a list of available browsers")
-        for i in webbrowser._browsers:
-            print("\t"+i)
-#end of printAvailableBrowsers
 
 class Search:
     def __init__(self, searchIn = None, engineIn = "google", domainIn = "ca"):
@@ -26,9 +18,9 @@ class Search:
         self.searchQuery = ""
         self.engine = engineIn
         self.domain = domainIn
-        self.url = "";
+        self.url = ""
         self.searchString = "/search?q="
-    #end of constructor    
+    #end of constructor
 
     #set search engine
     def setEngine(self, engineIn):
@@ -36,9 +28,14 @@ class Search:
     #end of setEngine
 
     #set domain engine
-    def setdomain(self, domainIn):
+    def setDomain(self, domainIn):
         self.domain = domainIn
     #end of setdomain
+    
+    #set search Query
+    def setQuery(self, searchIn):
+        self.searchRaw = searchIn
+    #end of setQuery
 
     def buildLink(self):
         if self.engine == "amazon":
@@ -53,21 +50,20 @@ class Search:
     #end of link building
 
     def openBrowser(self):
-        try:
-            browser = webbrowser.get(args.browser[0])
-            browser.open_new_tab(self.url)
-        except:
-            printAvailableBrowsers(args.browser[0])
+        webbrowser.open_new_tab(self.url)
     #end of openBrowser()
 #end of Query
 
-searchObj = Search(args.s)
+searchObj = Search()
+
 if args.engine is not None:
     searchObj.setEngine(args.engine[0])
 
 if args.domain is not None:
-    searchObj.setdomain(args.domain[0])
+    searchObj.setDomain(args.domain[0])
 #end of cmd args handling
 
-searchObj.buildLink()
-searchObj.openBrowser()
+for search in args.s:
+    searchObj.setQuery(search)
+    searchObj.buildLink()
+    searchObj.openBrowser()


### PR DESCRIPTION
Solves #8.
Search term is now encoded to make sure unsafe characters are not used. the quote() function is used to achieve this, and does not differ the search results
Note: this is on the updated -b/--browser version of `pySearch.py`