### PR TITLE
Adds Pip installation to pySearch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2018 Alex "jrkong" Kong (jrkong.hfd@gmail.com)
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ pySearch is a simple command line python script that allows for seamlessly perfo
 
 pySearch simplifies this to a single command line command.
 
-
 ## Getting Started
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,35 @@
 # pySearch
-
 pySearch is a simple command line python script that allows for seamlessly performing a web search without removing your hands off the keyboard as it opens a new browser tab to search the input string. Normally when working on a command line interface, a user would need to use their mouse to perform a web search as they would take one hand off the keyboard and navigate to their browser. Even when using ALT+TAB, users would still need to navigate to the search bar with the mouse and then return to the keyboard to type their search. 
 
 pySearch simplifies this to a single command line command.
 
 
 ## Getting Started
-
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
 ### Prerequisites
-
-Software you will need
-<ol>
- <li> Python - https://www.python.org/downloads/ </li>
- <li> Text Editor  - eg Visual Studio Code (if planning to edit this repo) </li>
-</ol>
+- Python  3 - https://www.python.org/downloads/ 
 
 ### Installing
-
-Clone this Repo  
-
+1. Clone the repository
+1. Navigate inside the repository
 For Windows: Command Line Prompt 
+1. Run `pip install -e`
         OSX: Terminal 
-
-To run use 
-
-python C:\Users\pySearch\pySearch.py  ( different path name where you have cloned pySearch into) 
+1. pySearch can be used by using `pySearch -s <search query>`
 
 #### Command Line Arguments 
- <ol>
- <li> -s  takes query to search</li>   
- <li> -e  changes name or alias of search engine and sets it to as search engine for session </li> 
- <li> -d  changes to domain extension </li>
- <li> -h  will provide description of command line arguments </li> 
- </ol>
+- `-s`  takes query to search
+  * multiple searches can be performed with multiple `-s` delimiters
+  * use quotes(" ") if searches contain `-s`
+- `-e`  changes name or alias of search engine and sets it to as search engine for session 
+- `-d`  changes to domain extension 
+- `-h`  provides a description of each command line argument
 
 ## Built With
-
 Python 3 
 
 ## Contributing
-
 ### Running the Tests
 pySearch tests use the [pytest](https://docs.pytest.org) library which is not part of the default Python library. If this is the first time pytest tests are being run on the machine use `pip install -r requirements.txt` to install pytest and it's dependencies (NOTE your `pip` alias may differ based on your installation). Afterwards pySearch tests can be run with the `pytest` command when inside the pySearch directory.
 
@@ -60,34 +48,22 @@ A list of errors will be returned that need to be fixed, please fix them before 
 your Pull Request!
 
 
-Please read [CONTRIBUTING.md] for details on our code of conduct, and the process for submitting pull requests to us.
-
-( To Be added )
-
+Please read [CONTRIBUTING.md (To Be added)]() for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Authors
+* **[Alex Kong](https://github.com/jrkong)** 
+* **[Alexander Ponomaroff]( https://github.com/alexander-ponomaroff )** 
 
-* **Alex Kong** ( https://github.com/jrkong )
-* **Alexander Ponomaroff** ( https://github.com/alexander-ponomaroff )
-
-See also the list of [contributors](https://github.com/your/project/contributors) who participated in this project. (TO be added) 
+See also the list of [contributors](https://github.com/your/project/contributors) who participated in this project. (To be added) 
 
 
 ## Objective 
-
 The goal of pySearch is to bring web search capabilities to your command line so initiating a web search doesn't require taking your hand off the keyboard. The current goal is to integrate as much of the web search workflow into the command line so users can get all the keyboard interaction out of the way before taking one hand off the keyboard to use the mouse to interact with the browser.
 
 ### Specific Goals 
-<ol>
- <li> Support webcrawling which would allow basic searches 
-     <ul> - Basic dictionary lookup would be a great test case for this, to be performed before opening a browser (think Unix man       pages. </ul> 
- </li>
- <li> Basic browser interactivity through pySearch 
-   <ul> - The ability to navigate and control your browser using pySearch (so scrolling, selecting and opening search links, open a new tab) </ul>
- </li>
- <li> pySearch's interactive mode shouldn't impede the user's ability to use command line commands 
-  <ul> - While it allows keyboard interactivity with the browser while inside the command line it should have the ability to pipe command line commands to the shell and return their output to the user </ul>
- </li>
-</ol>
-
-
+- Support webcrawling which would allow basic searches 
+      * Basic dictionary lookup would be a great test case for this, to be performed before opening a browser (think Unix man pages. 
+- Basic browser interactivity through pySearch 
+  * The ability to navigate and control your browser using pySearch (so scrolling, selecting and opening search links, open a new tab)
+      - pySearch's interactive mode shouldn't impede the user's ability to use command line commands 
+  * While it allows keyboard interactivity with the browser while inside the command line it should have the ability to pipe command line commands to the shell and return their output to the user

--- a/pySearch.py
+++ b/pySearch.py
@@ -2,13 +2,17 @@
 import argparse
 from search import Search
 
-argparser = argparse.ArgumentParser()
-argparser.add_argument("-s", action="append", help="Takes a query to search for and searches it.", nargs="*", required=True)
-argparser.add_argument("-e", "--engine", help="Changes the name or alias of a search engine and sets it as the search engine for the session", nargs="+")
-argparser.add_argument("-d", "--domain", help="Changes the domain extention", nargs="+")
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("-s", action="append", help="Takes a query to search for and searches it.", nargs="*", required=True)
+    argparser.add_argument("-e", "--engine", help="Changes the name or alias of a search engine and sets it as the search engine for the session", nargs="+")
+    argparser.add_argument("-d", "--domain", help="Changes the domain extention", nargs="+")
 
-args = argparser.parse_args()
+    args = argparser.parse_args()
+    searchObj = Search()
 
-searchObj = Search()
+    searchObj.handleArgs(args)
 
-searchObj.handleArgs(args)
+
+if __name__ == '__main__':
+    main()

--- a/search.py
+++ b/search.py
@@ -1,4 +1,3 @@
-
 import urllib
 import webbrowser
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="pySearch",
+    version="1.0",
+    author="jrkong",
+    author_email="jrkong.hfd@gmail.com",
+    description="cli tool for executing browser searches",
+    license='BSD',
+    url="https://github.com/jrkong/pySearch",
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'pySearch = pySearch:main',
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Environment :: Console"
+    ],
+    include_package_data=True,
+)


### PR DESCRIPTION
This PR builds on top of the test framework in PR #19.

This PR allows users the ability to install pySearch locally with pip. 
Updated the README with instructions on how to install pySearch and how to use it after it is installed.