### PR TITLE
Added configurations for pep8speaks bot, same as flake8

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,15 @@
+# File : .pep8speaks.yml
+
+scanner:
+    diff_only: True  # If True, errors caused by only the patch are shown
+
+pycodestyle:
+    max-line-length: 79
+    ignore:
+        - E251, # unexpected spaces around keyword / parameter equals
+        - E265, # block comment should start with '# '
+        - E302, # expected 2 blank lines, found 1
+        - E501, # line too long (105 > 79 characters)
+        - F401, # '...' imported but unused
+        - W292, # no newline at end of file
+        - W293 # blank line contains whitespace

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -13,3 +13,4 @@ pycodestyle:
         - F401, # '...' imported but unused
         - W292, # no newline at end of file
         - W293 # blank line contains whitespace
+        


### PR DESCRIPTION
Further expands on issue #29 .

Now we will have a local way to check for style and linting errors locally with flake8.
As well as with a pep8speaks bot on every pull request.