### PR TITLE
Added some Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ These instructions will get you a copy of the project up and running on your loc
 ### Installing
 1. Clone the repository
 1. Navigate inside the repository
-For Windows: Command Line Prompt 
-1. Run `pip install -e`
+For Windows: Use Command Line Prompt 
+For OSX: Use Terminal 
+1. Run `pip install -e .`
         OSX: Terminal 
-1. pySearch can be used by using `pySearch -s <search query>`
+1. pySearch can be used as follows:
+   
+ ```pySearch -s <search query> [-e <search engine>] [-d <domain>] [-h]```
+
 
 #### Command Line Arguments 
 - `-s`  takes query to search
@@ -30,7 +34,7 @@ Python 3
 
 ## Contributing
 ### Running the Tests
-pySearch tests use the [pytest](https://docs.pytest.org) library which is not part of the default Python library. If this is the first time pytest tests are being run on the machine use `pip install -r requirements.txt` to install pytest and it's dependencies (NOTE your `pip` alias may differ based on your installation). Afterwards pySearch tests can be run with the `pytest` command when inside the pySearch directory.
+pySearch tests use the [pytest](https://docs.pytest.org) library which is not part of the default Python library. If this is the first time pytest tests are being run on the machine navigate to the tests directiory and use `pip install -r requirements.txt` to install pytest and it's dependencies (NOTE your `pip` alias may differ based on your installation). Afterwards pySearch tests can be run with the `pytest` command when inside the pySearch directory.
 
 ### Style Enforcement with Flake8
 We are using Flake8 for style guide enforcement in pySearch.

--- a/search.py
+++ b/search.py
@@ -31,7 +31,8 @@ class Search:
             self.searchString = "/s/keywords="
             self.searchQuery = "%20".join(self.searchRaw)
         elif self.engine == "twitter":
-            self.searchQuery = " ".join(self.searchRaw)
+            self.setDomain("com")
+            self.searchQuery = "%20".join(self.searchRaw)
         else:
             self.searchQuery = "+".join(self.searchRaw)
         #end of search exceptions

--- a/tests/test_amazon.py
+++ b/tests/test_amazon.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ..search import Search
+
+def test_builtLinkAmazon():
+    tmpSearch = Search()
+    tmpSearch.setEngine("amazon")
+    tmpSearch.setQuery(["testing", "Amazon", "query"])
+    assert tmpSearch.buildLink() == "http://www.amazon.ca/s/keywords=testing%20Amazon%20query"

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ..search import Search
+
+def test_setDomain():
+    tmpSearch = Search()
+    tmpSearch.setDomain("org")
+    tmpSearch.setQuery(["test", "domain"])
+    assert tmpSearch.buildLink() == "http://www.google.org/search?q=test+domain"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,9 +2,27 @@ import pytest
 
 from ..search import Search
 
-def test_builtLink():
+def test_builtLinkAmazon():
     tmpSearch = Search()
     tmpSearch.setEngine("amazon")
     tmpSearch.setDomain("com")
-    tmpSearch.setQuery(["test", "query"])
-    assert tmpSearch.buildLink() == "http://www.amazon.com/s/keywords=test%20query"
+    tmpSearch.setQuery(["testing", "Amazon", "query"])
+    assert tmpSearch.buildLink() == "http://www.amazon.com/s/keywords=testing%20Amazon%20query"
+
+def test_builtLinkTwitter():
+    tmpSearch = Search()
+    tmpSearch.setEngine("twitter")
+    tmpSearch.setDomain("com")
+    tmpSearch.setQuery(["testing", "Twitter", "search"])
+    assert tmpSearch.buildLink() == "http://www.twitter.com/search?q=testing%20Twitter%20search"
+
+def test_builtLink():
+    tmpSearch = Search()
+    tmpSearch.setQuery(["test", "default"])
+    assert tmpSearch.buildLink() == "http://www.google.ca/search?q=test+default"
+
+def test_setDomain():
+    tmpSearch = Search()
+    tmpSearch.setDomain("org")
+    tmpSearch.setQuery(["test", "domain"])
+    assert tmpSearch.buildLink() == "http://www.google.org/search?q=test+domain"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,27 +2,7 @@ import pytest
 
 from ..search import Search
 
-def test_builtLinkAmazon():
-    tmpSearch = Search()
-    tmpSearch.setEngine("amazon")
-    tmpSearch.setDomain("com")
-    tmpSearch.setQuery(["testing", "Amazon", "query"])
-    assert tmpSearch.buildLink() == "http://www.amazon.com/s/keywords=testing%20Amazon%20query"
-
-def test_builtLinkTwitter():
-    tmpSearch = Search()
-    tmpSearch.setEngine("twitter")
-    tmpSearch.setDomain("com")
-    tmpSearch.setQuery(["testing", "Twitter", "search"])
-    assert tmpSearch.buildLink() == "http://www.twitter.com/search?q=testing%20Twitter%20search"
-
 def test_builtLink():
     tmpSearch = Search()
     tmpSearch.setQuery(["test", "default"])
     assert tmpSearch.buildLink() == "http://www.google.ca/search?q=test+default"
-
-def test_setDomain():
-    tmpSearch = Search()
-    tmpSearch.setDomain("org")
-    tmpSearch.setQuery(["test", "domain"])
-    assert tmpSearch.buildLink() == "http://www.google.org/search?q=test+domain"

--- a/tests/test_twitter.py
+++ b/tests/test_twitter.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ..search import Search
+
+def test_builtLinkTwitter():
+    tmpSearch = Search()
+    tmpSearch.setEngine("twitter")
+    tmpSearch.setQuery(["testing", "Twitter", "search"])
+    assert tmpSearch.buildLink() == "http://www.twitter.com/search?q=testing%20Twitter%20search"


### PR DESCRIPTION
per issue #16 this PR writes tests for: 
 - twitter search
 - google search
 - amazon search
 - default search
 - setting domain

Each test checks for one setting at a time. ie. twitter test checks that the url is correct when only the search query and engine are set. 

**Note that for the twitter search to work correctly the search.py had to be altered as I realized the twitter searches used %20 for spaces as well. The test also made apparent that setting the domain for twitter should not be allowed since `twitter.ca` does not exist. Therefore when the engine is twitter the domain is automatically set to `com`

I also noticed that the ReadMe had a mistake for the pip installation and added a fix for that.
